### PR TITLE
Fix initial input width

### DIFF
--- a/js/bootstrap-tokenfield.js
+++ b/js/bootstrap-tokenfield.js
@@ -161,7 +161,7 @@
     this.$element.prependTo( this.$wrapper )
 
     // Calculate inner input width
-    this.update()
+    setTimeout(this.update.bind(this), 0);
 
     // Create initial tokens, if any
     this.setTokens(this.options.tokens, false, ! this.$element.val() && this.options.tokens )


### PR DESCRIPTION
Currently the plugin initializes the input with the wrong width, being larger than it should and breaking the layout. 

Creating a token value fixes this, so I had a look over the source code and applied the same fix on initialize.